### PR TITLE
feat: Upgrade Cake.Core reference to 2.0.0

### DIFF
--- a/src/Cake.Npx.Tests/Cake.Npx.Tests.csproj
+++ b/src/Cake.Npx.Tests/Cake.Npx.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Testing" Version="1.0.0" />
+    <PackageReference Include="Cake.Testing" Version="2.0.0" />
     <PackageReference Include="FluentAssertions" Version="5.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />

--- a/src/Cake.Npx/Cake.Npx.csproj
+++ b/src/Cake.Npx/Cake.Npx.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <!-- Nuget: https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#nuget-metadata-properties -->
@@ -21,7 +21,7 @@
   <!-- End Nuget -->
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Sourcelink: https://github.com/dotnet/sourcelink/ -->


### PR DESCRIPTION
Also, followed the new suggestion to no longer target
the netstandard2.0 TFM but rather the netcoreapp3.1, net5.0
and net6.0 TFMs.

fixes #15 